### PR TITLE
Fix deployment issues from czhu12 / canine Issue #188 

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -48,16 +48,14 @@ spec:
               mountPath: /var/run/docker.sock
           {{- end }}
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           {{- if .Values.volumes.dockerSocket.enabled }}
           volumeMounts:
             - name: dockersock
-              mountPath: /var/run/docker.sock
+              mountPath: {{ .Values.volumes.dockerSocket.hostPath }}
           {{- end }}
           livenessProbe:
             tcpSocket:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -11,3 +11,4 @@ stringData:
   REDIS_URL: "redis://{{ include "canine.fullname" . }}-redis:6379"
   CANINE_USERNAME: {{ .Values.app.username | quote }}
   CANINE_PASSWORD: {{ .Values.app.password | quote }}
+  SECRET_KEY_BASE: {{ .Values.app.secretKey | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,7 @@ app:
   localMode: true
   username: "canine"
   password: "test1234h"
+  secretKey: "mysecretkey"
 
 # Service configuration
 service:


### PR DESCRIPTION
https://github.com/issues/recent?issue=czhu12%7Ccanine%7C188

- Fixed premature termination of pod caused by readiness probe
- Fixed liveness probe early termination caused by the same issue
- Added additional secrets required by canine pod
- Created parameter for docker socket

Deployed successfully with the following values file:

```yaml
app:
  port: "3456"
  username: "admin"
  password: "mysecret"
  host: "http://localhost:3456"
  localMode: true 
  secretKey: "mysecretkey"

postgresql:
  auth:
    username: "postgresql"
    password: "postgresql"

service:
  port: 3456
  type: LoadBalancer

image:
  repository: chriszhu12/canine
  tag: latest@sha256:b2dbc2e00c4cb3e3e6c79bec793652c158de50964da99bd587084789f81246ce

volumes:
  dockerSocket:
    hostPath: /var/run/k3s/containerd/containerd.sock
```